### PR TITLE
Use bundler to manage required ruby version

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm use 1.9.3@billbo --create --default

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,13 @@
 source 'https://rubygems.org'
 
+ruby '1.9.3'
+
 gem 'sinatra'
 gem 'sinatra-r18n'
 gem 'sinatra-flash'
 gem 'sinatra-redirect-with-flash'
 
-gem "rmagick", '~> 2.13.2'
+gem 'rmagick', '~> 2.13.2'
 
 gem 'mongoid', '~> 3.1.4'
 


### PR DESCRIPTION
`.rvmrc` is a rvm specific configuration file, so other developers using other ruby management tools (like `rbenv` or `chruby`) might have problems. Bundler (> 1.2) can handle the required ruby version for the project, so it should be a better solution.
